### PR TITLE
Scan Geomtries

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,7 @@ makedocs(;
         ],
         "API" => [
             "Light Sources" => "api/chromatic.md",
+            "Scan Geometry" => "api/geometry.md",
         ]
     ],
 )

--- a/docs/src/api/geometry.md
+++ b/docs/src/api/geometry.md
@@ -1,0 +1,15 @@
+# Scan Geometry 
+
+The following types and functions describe the creation of scan geometries 
+for the simulation. 
+
+```@index 
+Pages   = ["geometry.md"]
+Order   = [:constant, :type, :function]
+```
+
+```@autodocs 
+Modules = [ComputedTomography]
+Order   = [:constant,:type,:function]
+Pages   = ["scan_geometry.jl"]
+```

--- a/src/ComputedTomography.jl
+++ b/src/ComputedTomography.jl
@@ -1,7 +1,10 @@
 module ComputedTomography
 
 include("chromatic.jl")
+include("scan_geometry.jl")
 
 export Monochromatic, Polychromatic
+export ParallelBeam, FanBeam 
+export generate
 
 end

--- a/src/chromatic.jl
+++ b/src/chromatic.jl
@@ -4,13 +4,13 @@
 """
     ENERGY_MIN = 1.0 (keV)
 
-The minimum energy of a simulate X-ray beam.
+The minimum energy of a simulated X-ray beam.
 """
 const ENERGY_MIN = 1.0 #keV
 """
     ENERGY_MAX = 120.0 (keV)
 
-The maximum energy of a simulate X-ray beam.
+The maximum energy of a simulated X-ray beam.
 """
 const ENERGY_MAX = 120.0 #keV
 

--- a/src/scan_geometry.jl
+++ b/src/scan_geometry.jl
@@ -92,7 +92,7 @@ A data structure specifying a 2-dimensional fan beam scan geometry.
 # Fields 
 - `angle::Float64`, a value in `[0, π]` that specifies the angle (radians) of the fan 
     beam.
-- `num_sources::Int64``, the number of beams eminating from the source.
+- `num_sources::Int64``, the number of beams emanating from the source.
 - `rotation_step::Float64`, a value in `(0, π)` that specifies the amount the 
     source is rotated in a single increment around the object being scanned 
     in radians.

--- a/src/scan_geometry.jl
+++ b/src/scan_geometry.jl
@@ -49,7 +49,7 @@ A data structure specifying a 2-dimensional parallel beam scan geometry.
 struct ParallelBeam <: ScanGeometry 
     width_ratio::Float64 # Width ratio of the scan geometry
     num_sources::Int64 # Number of sources in the scan geometry
-    rotation_step::Float64 # Rotoation step in radians 
+    rotation_step::Float64 # Rotation step in radians 
     
     ParallelBeam(
         width_ratio::Float64, 

--- a/src/scan_geometry.jl
+++ b/src/scan_geometry.jl
@@ -1,0 +1,259 @@
+###################################
+# Data Structures
+###################################
+"""
+    Beam 
+
+A data structure representing a single X-ray beam direction. 
+
+# Fields 
+- `source::Tuple{Float64, Float64}`, the source position of an X-ray beam in 2D 
+    space specified by a pair (x, y) that assumes an (absolute) underlying Cartesian 
+    coordinate system. 
+- `direction::Tuple{Float64, Float64}`, the direction of the beam in 2D space 
+    specified by a pair (x, y) that assuming an (absolute) underlying Cartesian coordinate 
+    system. 
+"""
+mutable struct Beam 
+    source::Tuple{Float64, Float64}
+    direction::Tuple{Float64, Float64}
+end
+
+"""
+    ScanGeometry 
+
+An abstract type representing a scan geometry used in the CT simulation.
+"""
+abstract type ScanGeometry end 
+
+"""
+    ParallelBeam <: ScanGeometry 
+
+A data structure specifying a 2-dimensional parallel beam scan geometry.
+    The scan geometry is a parallel set of beams. These are then rotated around 
+    the object being scanned.
+
+# Fields
+- `width_ratio::Float64`, a value in `[0, 1]` that specifies the width of the 
+    distance between the two furtherest sources (along the secant) as a fraction 
+    of the width of the diameter of rotation. 
+- `num_sources::Int64`, the number of sources spread out along the indicated 
+    width ratio. 
+- `rotation_step::Float64`, a value in `(0, π)` that specifies the amount the 
+    source is rotated in a single increment around the object being scanned 
+    in radians.
+
+!!! info 
+    The width ratio must be zero if the number of sources is one. 
+"""
+struct ParallelBeam <: ScanGeometry 
+    width_ratio::Float64 # Width ratio of the scan geometry
+    num_sources::Int64 # Number of sources in the scan geometry
+    rotation_step::Float64 # Rotoation step in radians 
+    
+    ParallelBeam(width_ratio::Float64, num_sources::Int64) = begin 
+        (width_ratio < 0 || width_ratio > 1) && throw(
+            DomainError("Width ratio must be in [0, 1].")
+        )
+        (num_sources <= 0) && throw(
+            DomainError("Number of sources must be a positive integer.")
+        )
+
+        (num_sources == 1 && width_ratio != 0.0) && throw(
+            DomainError("Width ratio must be zero if the number of sources is one.")
+        )
+
+        (rotation_step <= 0 || rotation_step >= π) && throw(
+            DomainError("Rotation step must be in (0, π).")
+        )
+
+        new(width_ratio, num_sources, rotation_step)
+    end
+end
+
+"""
+    FanBeam <: ScanGeometry 
+
+A data structure specifying a 2-dimensional fan beam scan geometry. 
+    The scan geometry is assumed to generate a fan shape that is then rotated 
+    around the object being scanned. 
+
+# Fields 
+- `angle::Float64`, a value in `[0, π]` that specifies the angle (radians) of the fan 
+    beam.
+- `num_sources::Int64``, the number of beams eminating from the source.
+- `rotation_step::Float64`, a value in `(0, π)` that specifies the amount the 
+    source is rotated in a single increment around the object being scanned 
+    in radians.
+"""
+struct FanBeam <: ScanGeometry 
+    angle::Float64 #Angle of the fan beam in radians 
+    num_sources::Int64 # Number of sources in the scan geometry
+    rotation_step::Float64 # Rotoation step in radians 
+
+    FanBeam(angle::Float64, num_sources::Int64) = begin 
+        (angle < 0 || angle > π) && throw(
+            DomainError("Angle must be in [0, π].")
+        )
+
+        (num_sources <= 0) && throw(
+            DomainError("Number of sources must be a positive integer.")
+        )
+
+        (num_sources == 1 && angle != 0.0) && throw(
+            DomainError("Angle must be zero if the number of sources is one.")
+        )
+
+        (rotation_step <= 0 || rotation_step >= π) && throw(
+            DomainError("Rotation step must be in (0, π).")
+        )
+
+        new(angle, num_sources, rotation_step)
+    end
+end
+
+###################################
+# Methods 
+###################################
+"""
+    generate_from_baseline(
+        baseline_x_positions::Vector{Float64},
+        baseline_y_positions::Vector{Float64},
+        baseline_x_directions::Vector{Float64},
+        baseline_y_directions::Vector{Float64},
+        rotation_angles::Vector{Float64},
+    )
+
+Generates a vector of `Beam` objects from the baseline positions and directions
+    by rotating the baselines through the angles specified in `rotation_angles`.
+"""
+function generate_from_baseline(
+    baseline_x_positions::Vector{Float64},
+    baseline_y_positions::Vector{Float64},
+    baseline_x_directions::Vector{Float64},
+    baseline_y_directions::Vector{Float64},
+    rotation_angles::Vector{Float64},
+)
+
+    # Check that all vectors are of the same length
+    num_sources = length(baseline_x_positions)
+    (
+        length(baseline_y_positions) != num_sources ||
+        length(baseline_x_directions) != num_sources ||
+        length(baseline_y_directions) != num_sources
+    ) && throw(
+        DomainError("All baseline vectors must have the same length.")
+    )
+
+    # Generate Beams for each rotation angle 
+    beams = Vector{Beam}(undef, length(rotation_angles) * num_sources)
+
+    counter = 1
+    for angle in rotation_angles
+        for source in Base.OneTo(num_sources)
+            # Calculate x-y position 
+            x_pos = cos(angle) * baseline_x_positions[source] - 
+                sin(angle) * baseline_y_positions[source]
+
+            y_pos = sin(angle) * baseline_x_positions[source] + 
+                cos(angle) * baseline_y_positions[source]
+           
+            # Calculate beam direction
+            x_dir = cos(angle) * baseline_x_directions[source] - 
+                sin(angle) * baseline_y_directions[source]
+
+            y_dir = sin(angle) * baseline_x_directions[source] +
+                cos(angle) * baseline_y_directions[source]
+
+            # Create Beam 
+            beams[counter].source = (x_pos, y_pos)
+            beams[counter].direction = (x_dir, y_dir)
+            counter += 1
+        end
+    end
+
+    return beams
+end
+
+"""
+    generate(geometry::G, radius::Float64) where G<:ScanGeometry
+
+Determines the source positions and beam directions of the scan geometry specified 
+    by `geometry` and the radius of rotation specified by `radius`.
+
+# Arguments 
+- `geometry<:ScanGeometry`, the scan geometry for which to generate the beams.
+- `radius::Float64`, the radius of rotation around the object being scanned. 
+    This value must be positive and cannot be zero.
+
+# Returns 
+- `::Vector{Beam}`, a vector of `Beam` objects representing the source 
+    positions and beam directions of the scan geometry.
+
+# Throws 
+- `DomainError`, if the radius of rotation is not positive.
+"""
+function generate(geometry::ParallelBeam, radius::Float64)
+
+    (radius <= 0) && throw(
+        DomainError("Radius of rotation must be a positive value.")
+    )
+
+    # Generate Baseline values (angle of rotation is 0) 
+    
+    ## Determine x-positions 
+    baseline_x_positions = range(
+        -radius*geometry.width_ratio, 
+        radius*geometry.width_ratio, 
+        length=geometry.num_sources
+    )
+
+    ## Determine y-positions 
+    baseline_y_positions = Float64[ -sqrt(radius^2 - x^2) for x in x_positions]
+
+    ## Generate beam directions 
+    baseline_x_directions = zeros(Float64, geometry.num_sources)
+    baseline_y_directions = ones(Float64, geometry.num_sources)
+
+    # Rotation Angles; do not repeat collection at π since we already collect
+    # at 0 radians. 
+    rotation_angles = 0:geometry.rotation_step:(π-eps(π)) 
+
+    # Generate Beams for each rotation angle     
+    return generate_from_baseline(
+        baseline_x_positions,
+        baseline_y_positions,
+        baseline_x_directions,
+        baseline_y_directions,
+        rotation_angles
+    )
+end
+function generate(geometry::FanBeam, radius::Float64)
+    
+    (radius <= 0) && throw(
+        DomainError("Radius of rotation must be a positive value.")
+    )
+
+    # Generate Baseline x-positions and y-positions 
+    baseline_x_positions = zeros(Float64, geometry.num_sources)
+    baseline_y_positions = -radius.* ones(Float64, geoemtry.num_sources)
+
+    # Generate Beam Directions 
+    beam_angle = range(-geometry.angle/2, geometry.angle/2, geometry.num_sources)
+    baseline_x_direction = cos.(beam_angle) 
+    baseline_y_direction = sin.(beam_angle)
+
+    # Rotation Angles; do not repeat collection at π since we already collect
+    # at 0 radians. 
+    rotation_angles = 0:geometry.rotation_step:(π-eps(π)) 
+
+    # Generate Beams for each rotation angle     
+    return generate_from_baseline(
+        baseline_x_positions,
+        baseline_y_positions,
+        baseline_x_directions,
+        baseline_y_directions,
+        rotation_angles
+    )
+end
+

--- a/src/scan_geometry.jl
+++ b/src/scan_geometry.jl
@@ -100,7 +100,7 @@ A data structure specifying a 2-dimensional fan beam scan geometry.
 struct FanBeam <: ScanGeometry 
     angle::Float64 #Angle of the fan beam in radians 
     num_sources::Int64 # Number of sources in the scan geometry
-    rotation_step::Float64 # Rotoation step in radians 
+    rotation_step::Float64 # Rotation step in radians 
 
     FanBeam(angle::Float64, num_sources::Int64, rotation_step::Float64) = begin 
         (angle < 0 || angle > π) && throw(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,5 @@ using Test
 
 @testset "ComputedTomography.jl" begin
     include("src/chromatic.jl")
+    include("src/scan_geometry.jl")
 end

--- a/test/src/scan_geometry.jl
+++ b/test/src/scan_geometry.jl
@@ -1,0 +1,174 @@
+module testscangeometry 
+
+using ..Test 
+using ..ComputedTomography 
+CT = ComputedTomography
+
+@testset "Scan Geometry: Beam" begin
+
+    # Test Beam constructor with valid inputs 
+    let beam = CT.Beam((1.0, 2.0), (0.0, 1.0))
+        @test beam.source == (1.0, 2.0)
+        @test beam.direction == (0.0, 1.0)
+    end
+
+    # Test overwriting of beam 
+    let beam = CT.Beam((1.0, 2.0), (0.0, 1.0)),
+        new_source = (3.0, 4.0),
+        new_direction = (1.0, 0.0)
+        
+        beam.source = new_source
+        beam.direction = new_direction 
+
+        @test beam.source == new_source
+        @test beam.direction == new_direction
+    end
+end
+
+@testset "Scan Geometry: Parallel Beam" begin
+
+    error_arguments = [
+        (-1.0, 10, 0.1), # Negative width ratio
+        (1.5, 10, 0.1), # Width ratio larger than 1
+        (0.5, 0, 0.1), # Non-positive number of sources
+        (0.5, 1, 0.1), # One source with non-zero width ratio
+        (0.0, 2, 0.1), # More than one source with zero width
+        (0.5, 2, 0.0), # Non-positive rotation step
+        (0.5, 2, 3.2) # Rotation step exceeds π
+    ]
+
+    for (width_ratio, num_sources, rotation_step) in error_arguments
+        @test_throws DomainError ParallelBeam(width_ratio, num_sources, rotation_step)
+    end
+
+    # Correct functioning of constructor 
+    let width_ratio = 0.5, num_sources = 10, rotation_step = 0.1 
+
+        beam = ParallelBeam(width_ratio, num_sources, rotation_step)
+        @test beam.width_ratio == width_ratio
+        @test beam.num_sources == num_sources
+        @test beam.rotation_step == rotation_step
+    end
+end
+
+@testset "Scan Geometry: Fan Beam" begin 
+
+    error_arguments = [
+        (0.0, 10, 0.1), # Zero angle
+        (3.2, 10, 0.1), # Angle exceeds π
+        (1.0, 0, 0.1), # Non-positive number of sources
+        (1.0, 1, 0.1), # One source with non-zero angle 
+        (0.0, 2, 0.1), # More than one source with zero angle 
+        (1.0, 2, 0.0), # Non-positive rotation step
+        (1.0, 2, 3.2) # Rotation step exceeds π
+    ]
+
+    for (angle, num_sources, rotation_step) in error_arguments
+        @test_throws DomainError FanBeam(angle, num_sources, rotation_step)
+    end
+
+    # Correct functioning of constructor 
+    let angle = 1.0, num_sources = 10, rotation_step = 0.1 
+
+        beam = FanBeam(angle, num_sources, rotation_step)
+        @test beam.angle == angle
+        @test beam.num_sources == num_sources
+        @test beam.rotation_step == rotation_step
+    end
+
+end
+
+@testset "Scan Geometry: Generate Beams from Baseline" begin
+    
+    # Tests that all positions and directions are same length
+    let x_positions = [0.0, 1.0, 2.0], 
+        y_positions = [-1.0, 0.0],
+        x_directions = [-1.0, 0.0],
+        y_directions = [0.0, 1.0],
+        rotation_angles = [0.0, π/2]
+
+        @test_throws DomainError CT.generate_from_baseline(
+            x_positions, 
+            y_positions, 
+            x_directions, 
+            y_directions, 
+            rotation_angles
+        )
+    end
+
+    # Tests that all positions and directions are correctly generated 
+    let x_positions = [0.0, 1.0], 
+        y_positions = [-1.0, 0.0],
+        x_directions = [-1.0, 0.0],
+        y_directions = [0.0, 1.0],
+        rotation_angles = [π/2]
+
+        beams = CT.generate_from_baseline(
+            x_positions, 
+            y_positions, 
+            x_directions, 
+            y_directions, 
+            rotation_angles
+        )
+
+        @test length(beams) == 2 
+        @test beams[1].source[1] ≈ 1.0 
+        @test beams[1].source[2] ≈ 0.0 atol=eps()
+        @test beams[1].direction[1] ≈ 0.0 atol=eps()
+        @test beams[1].direction[2] ≈ -1.0
+        @test beams[2].source[1] ≈ 0.0 atol=eps()
+        @test beams[2].source[2] ≈ 1.0
+        @test beams[2].direction[1] ≈ -1.0 
+        @test beams[2].direction[2] ≈ 0.0 atol=eps()
+    end
+end
+
+@testset "Scan Geometry: Generate Parallel Beams" begin 
+
+    # Incorrect Radius Argument 
+    let geometry = ParallelBeam(0.0, 1, π/2), radius = 0.0 
+        @test_throws DomainError generate(geometry, radius)
+    end
+
+    # Correct functioning of parallel beam generation 
+    let geometry = ParallelBeam(0.0, 1, π/2), radius = 1.0
+
+        beams = generate(geometry, radius)
+
+        @test length(beams) == 2
+        @test beams[1].source[1] ≈ 0.0 atol=eps()
+        @test beams[1].source[2] ≈ -1.0 atol=eps()
+        @test beams[2].source[1] ≈ 1.0 atol=eps()
+        @test beams[2].source[2] ≈ 0.0 atol=eps()
+        @test beams[1].direction[1] ≈ 0.0 atol=eps()
+        @test beams[1].direction[2] ≈ 1.0 atol=eps() 
+        @test beams[2].direction[1] ≈ -1.0 atol=eps()
+        @test beams[2].direction[2] ≈ 0.0 atol=eps()
+    end
+end
+
+@testset "Scan Geometry: Generate Fan Beams" begin 
+
+    # Incorrect Radius Argument 
+    let geometry = FanBeam(0.0, 1, π/2), radius = 0.0 
+        @test_throws DomainError generate(geometry, radius)
+    end
+    
+    # Correct Functioning 
+    let geometry = FanBeam(0.0, 1, π/2), radius = 1.0
+
+        beams = generate(geometry, radius)
+
+        @test length(beams) == 2
+        @test beams[1].source[1] ≈ 0.0 atol=eps()
+        @test beams[1].source[2] ≈ -1.0 atol=eps()
+        @test beams[2].source[1] ≈ 1.0 atol=eps()
+        @test beams[2].source[2] ≈ 0.0 atol=eps()
+        @test beams[1].direction[1] ≈ 0.0 atol=eps()
+        @test beams[1].direction[2] ≈ 1.0 atol=eps() 
+        @test beams[2].direction[1] ≈ -1.0 atol=eps()
+        @test beams[2].direction[2] ≈ 0.0 atol=eps()
+    end
+end
+
+end # module testscangeometry


### PR DESCRIPTION
This PR implements `Beam`s and `ScanGeometry`.

- A `Beam` is an object that specifies the source of an X-ray beam and its direction of travel in two dimensional space with respect to an absolute Cartesian coordinate system.
- `ScanGeometry`s are specifications of creating a collection of beams from a single or multiple rotating sources. 

Two `ScanGeometry`s are implemented.
- Parallel Beam geometry, which generates parallel beams based on user-specified parameters. 
- Fan Beam geometry, which generates beams forming a fan based on user-specified parameters.